### PR TITLE
Update configure.sh to move agents.json

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -6,7 +6,8 @@ while [ 1 ]
 do
   wget -qO- http://leader.mesos:5050/state-summary \
     | rq -jJ "at slaves | spread | at hostname | map (ip) => { ip + ':61091' } | collect | map (n)=>{ {'targets':n} } | collect" \
-    > /tmp/agents.json
-
+    > /tmp/agents.json.new
+  mv /tmp/agents.json.new /tmp/agents.json
+  
   sleep 60
 done


### PR DESCRIPTION
First writing whole agents.json and moving it afterwards in place to prevent "unexpected end of JSON input" errors.
`caller=file.go:205 component="target manager" discovery=file msg="Error reading file" path=/tmp/agents.json err="unexpected end of JSON input"`

The "move" operation is faster since it is only an Inode operation, which causes prometheus always to see the complete file and not only parts, if fetching data from mesos api takes longer.